### PR TITLE
populate test_db and add basic tests

### DIFF
--- a/populate_test_db.sh
+++ b/populate_test_db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# download 7-dump
+curl -o 7-dump.sql "https://s3.amazonaws.com/intranet-projects-files/holbertonschool-higher-level_programming+/290/7-states_list.sql"
+
+# remove db and user creations
+for i in {1..10}
+do
+    sed -i '18d' 7-dump.sql
+done
+
+# change use statement
+sed -i 's/_dev/_test/' 7-dump.sql
+
+# import mysqldump 
+cat 7-dump.sql | mysql -uhbnb_test -phbnb_test_pwd
+
+# cleanup
+rm 7-dump.sql

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -16,11 +16,28 @@ from models.state import State
 from models.user import User
 import json
 import os
+import subprocess
 import pep8
 import unittest
 DBStorage = db_storage.DBStorage
 classes = {"Amenity": Amenity, "City": City, "Place": Place,
            "Review": Review, "State": State, "User": User}
+
+# initialize new instance of hbnb_test_db
+
+# cmd line: HBNB_ENV=test HBNB_MYSQL_USER=hbnb_test \
+#           HBNB_MYSQL_PWD=hbnb_test_pwd \
+#           HBNB_MYSQL_HOST=localhost \
+#           HBNB_MYSQL_DB=hbnb_test_db \
+#           HBNB_TYPE_STORAGE=db \
+#           python3 -m unittest discover tests
+storage = DBStorage()
+# populate empty hbnb_test_db with 7-dump.sql
+# !!! must have hbnb_test user created !!!
+#    and with permission to hbnb_test_db
+#     run setup_mysql_test.sql as root
+subprocess.call("./populate_test_db.sh", shell=True)
+storage.reload()
 
 
 class TestDBStorageDocs(unittest.TestCase):
@@ -72,17 +89,120 @@ class TestFileStorage(unittest.TestCase):
     """Test the FileStorage class"""
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_returns_dict(self):
-        """Test that all returns a dictionaty"""
-        self.assertIs(type(models.storage.all()), dict)
+        """Test that all returns a dictionary"""
+        states_dict = storage.all("State")
+        self.assertIs(type(states_dict), dict)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_no_class(self):
         """Test that all returns all rows when no class is passed"""
+        state_names = [
+            'Alabama', 'Arizona', 'California',
+            'Colorado', 'Florida', 'Georgia',
+            'Hawaii', 'Illinois', 'Indiana',
+            'Louisiana', 'Minnesota',
+            'Mississippi', 'Oregon'
+        ]
+        city_names = [
+            'Joliet', 'Tupelo', 'Babbie', 'Kearny',
+            'Tempe', 'Calera', 'Miami', 'Jackson',
+            'Saint Paul', 'Baton rouge', 'Sonoma',
+            'Lafayette', 'Peoria', 'Fremont', 'Denver',
+            'Chicago', 'Honolulu', 'Orlando', 'Douglas',
+            'Portland', 'Akron', 'Eugene', 'New Orleans',
+            'San Jose', 'Meridian', 'Urbana', 'Kailua',
+            'Napa', 'Naperville', 'Pearl city',
+            'Fairfield', 'San Francisco'
+        ]
+        # known inital import data
+        initial_data = state_names + city_names
+
+        # load object from db_storage
+        items = storage.all().values()
+
+        all_items = []
+        for item in items:
+            all_items.append(item.name)
+
+        # are they different
+        not_in_initial = list(set(initial_data)-set(all_items))
+        not_in_all_items = list(set(all_items)-set(initial_data))
+        # list of combined differences
+        diff = list(not_in_initial + not_in_all_items)
+        self.assertTrue(diff == [])
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_new(self):
         """test that new adds an object to the database"""
+        # add objects to the session using State
+        states = storage.all("State").values()
+
+        # create list of states as base case
+        before = []
+        for state in states:
+            before.append(state.name)
+        # create new State object
+        new_state = State(name="Fake_State")
+
+        # call new function ; update objects of the session
+        storage.new(new_state)
+        states = storage.all("State").values()
+
+        # create test list of states
+        after = []
+        for state in states:
+            after.append(state.name)
+
+        # only one item was added
+        self.assertTrue(len(after) - len(before) == 1)
+
+        # the item added was 'Fake_State'
+        not_in_before = list(set(before)-set(after))
+        not_in_after = list(set(after)-set(before))
+        diff = list(not_in_before + not_in_after)
+        self.assertTrue(diff[0] == "Fake_State")
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_delete(self):
+        """Test that save properly saves objects to file.json"""
+        # add objects to the session using State
+        new_state = State(name="Fake_State")
+        storage.new(new_state)
+        storage.save()
+        states = storage.all("State").values()
+
+        # create list of states as base case
+        before = []
+        for state in states:
+            before.append(state.name)
+        # create new State object
+
+        # call new function ; update objects of the session
+        storage.delete(new_state)
+        storage.save()
+        states = storage.all("State").values()
+
+        # create test list of states
+        after = []
+        for state in states:
+            after.append(state.name)
+
+        # only one item was deleted
+        self.assertTrue(len(after) - len(before) == -1)
+
+        # the item deleted was 'Fake_State'
+        not_in_before = list(set(before)-set(after))
+        not_in_after = list(set(after)-set(before))
+        diff = list(not_in_before + not_in_after)
+        self.assertTrue(diff[0] == "Fake_State")
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
-        """Test that save properly saves objects to file.json"""
+        """
+        Save is called in test_new and in test_delete.
+        If the storage items, mysql data objects, are not persisted, meaing
+        saved/commited to the database, then an error occurs:
+                Instance '<State at 0x7fc0980ffdd8>' is not persisted.
+        Therefore, save is verified working during the delete test
+        """
+        pass


### PR DESCRIPTION
Added a bash script to download and populate hbnb_test_db

In test_db_sotrage.py, added tests for the following function for db_storage.py:
all() - with argument
all() - without argument
new()
delete()

Also, I encounter a '_not enough memory error_' after running the unittest command a number of times.