### PR TITLE
added get() and count() to both filestorage engines

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -4,8 +4,8 @@ Contains the class DBStorage
 """
 
 import models
-from models.amenity import Amenity
 from models.base_model import BaseModel, Base
+from models.amenity import Amenity
 from models.city import City
 from models.place import Place
 from models.review import Review
@@ -74,3 +74,17 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """get specific object"""
+        objs = self.all(cls).values()
+        if len(objs) > 0:
+            for obj in objs:
+                if obj.id == id:
+                    return obj
+        return None
+
+    def count(self, cls=None):
+        """gets count of cls objs"""
+        objs = self.all(cls)
+        return len(objs)

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -4,6 +4,7 @@ Contains the FileStorage class
 """
 
 import json
+import models
 from models.amenity import Amenity
 from models.base_model import BaseModel
 from models.city import City
@@ -55,7 +56,7 @@ class FileStorage:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except:
+        except FileNotFoundError:
             pass
 
     def delete(self, obj=None):
@@ -68,3 +69,17 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """get specific object"""
+        objs = self.all(cls).values()
+        if len(objs) > 0:
+            for obj in objs:
+                if obj.id == id:
+                    return obj
+        return None
+
+    def count(self, cls=None):
+        """gets count of cls objs"""
+        objs = self.all(cls)
+        return len(objs)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -16,11 +16,28 @@ from models.state import State
 from models.user import User
 import json
 import os
+import subprocess
 import pep8
 import unittest
 DBStorage = db_storage.DBStorage
 classes = {"Amenity": Amenity, "City": City, "Place": Place,
            "Review": Review, "State": State, "User": User}
+
+# initialize new instance of hbnb_test_db
+
+# cmd line: HBNB_ENV=test HBNB_MYSQL_USER=hbnb_test \
+#           HBNB_MYSQL_PWD=hbnb_test_pwd \
+#           HBNB_MYSQL_HOST=localhost \
+#           HBNB_MYSQL_DB=hbnb_test_db \
+#           HBNB_TYPE_STORAGE=db \
+#           python3 -m unittest discover tests
+storage = DBStorage()
+# populate empty hbnb_test_db with 7-dump.sql
+# !!! must have hbnb_test user created !!!
+#    and with permission to hbnb_test_db
+#     run setup_mysql_test.sql as root
+subprocess.call("./populate_test_db.sh", shell=True)
+storage.reload()
 
 
 class TestDBStorageDocs(unittest.TestCase):
@@ -68,21 +85,141 @@ test_db_storage.py'])
                             "{:s} method needs a docstring".format(func[0]))
 
 
-class TestFileStorage(unittest.TestCase):
+class TestDBStorage(unittest.TestCase):
     """Test the FileStorage class"""
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_returns_dict(self):
-        """Test that all returns a dictionaty"""
-        self.assertIs(type(models.storage.all()), dict)
+        """Test that all returns a dictionary"""
+        states_dict = storage.all("State")
+        self.assertIs(type(states_dict), dict)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_no_class(self):
         """Test that all returns all rows when no class is passed"""
+        state_names = [
+            'Alabama', 'Arizona', 'California',
+            'Colorado', 'Florida', 'Georgia',
+            'Hawaii', 'Illinois', 'Indiana',
+            'Louisiana', 'Minnesota',
+            'Mississippi', 'Oregon'
+        ]
+        city_names = [
+            'Joliet', 'Tupelo', 'Babbie', 'Kearny',
+            'Tempe', 'Calera', 'Miami', 'Jackson',
+            'Saint Paul', 'Baton rouge', 'Sonoma',
+            'Lafayette', 'Peoria', 'Fremont', 'Denver',
+            'Chicago', 'Honolulu', 'Orlando', 'Douglas',
+            'Portland', 'Akron', 'Eugene', 'New Orleans',
+            'San Jose', 'Meridian', 'Urbana', 'Kailua',
+            'Napa', 'Naperville', 'Pearl city',
+            'Fairfield', 'San Francisco'
+        ]
+        # known inital import data
+        initial_data = state_names + city_names
+
+        # load object from db_storage
+        items = storage.all().values()
+
+        all_items = []
+        for item in items:
+            all_items.append(item.name)
+
+        # are they different
+        not_in_initial = list(set(initial_data)-set(all_items))
+        not_in_all_items = list(set(all_items)-set(initial_data))
+        # list of combined differences
+        diff = list(not_in_initial + not_in_all_items)
+        self.assertTrue(diff == [])
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_new(self):
         """test that new adds an object to the database"""
+        # add objects to the session using State
+        states = storage.all("State").values()
+
+        # create list of states as base case
+        before = []
+        for state in states:
+            before.append(state.name)
+        # create new State object
+        new_state = State(name="Fake_State")
+
+        # call new function ; update objects of the session
+        storage.new(new_state)
+        states = storage.all("State").values()
+
+        # create test list of states
+        after = []
+        for state in states:
+            after.append(state.name)
+
+        # only one item was added
+        self.assertTrue(len(after) - len(before) == 1)
+
+        # the item added was 'Fake_State'
+        not_in_before = list(set(before)-set(after))
+        not_in_after = list(set(after)-set(before))
+        diff = list(not_in_before + not_in_after)
+        self.assertTrue(diff[0] == "Fake_State")
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_delete(self):
+        """Test that save properly saves objects to file.json"""
+        # add objects to the session using State
+        new_state = State(name="Fake_State")
+        storage.new(new_state)
+        storage.save()
+        states = storage.all("State").values()
+
+        # create list of states as base case
+        before = []
+        for state in states:
+            before.append(state.name)
+        # create new State object
+
+        # call new function ; update objects of the session
+        storage.delete(new_state)
+        storage.save()
+        states = storage.all("State").values()
+
+        # create test list of states
+        after = []
+        for state in states:
+            after.append(state.name)
+
+        # only one item was deleted
+        self.assertTrue(len(after) - len(before) == -1)
+
+        # the item deleted was 'Fake_State'
+        not_in_before = list(set(before)-set(after))
+        not_in_after = list(set(after)-set(before))
+        diff = list(not_in_before + not_in_after)
+        self.assertTrue(diff[0] == "Fake_State")
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
-        """Test that save properly saves objects to file.json"""
+        """
+        Save is called in test_new and in test_delete.
+        If the storage items, mysql data objects, are not persisted, meaing
+        saved/commited to the database, then an error occurs:
+                Instance '<State at 0x7fc0980ffdd8>' is not persisted.
+        Therefore, save is verified working during the delete test
+        """
+        pass
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_dbcount(self):
+        """tests count"""
+        pre = storage.count("Amenity")
+        test_obj = Amenity(name="foo")
+        storage.new(test_obj)
+        post = storage.count("Amenity")
+        self.assertEqual(pre + 1, post)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_dbget(self):
+        """tests get"""
+        test_obj = Amenity(name="bar")
+        storage.new(test_obj)
+        data = storage.get("Amenity", test_obj.id)
+        self.assertEqual(id(test_obj), id(data))

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -6,6 +6,7 @@ Contains the TestFileStorageDocs classes
 from datetime import datetime
 import inspect
 import models
+from models import storage
 from models.engine import file_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
@@ -113,3 +114,20 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """tests count"""
+        pre = storage.count("Amenity")
+        test_obj = Amenity(name="foo")
+        storage.new(test_obj)
+        post = storage.count("Amenity")
+        self.assertEqual(pre + 1, post)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """tests get"""
+        test_obj = Amenity(name="bar")
+        storage.new(test_obj)
+        data = storage.get("Amenity", test_obj.id)
+        self.assertEqual(id(test_obj), id(data))


### PR DESCRIPTION
added get() and count() to both filestorage engines:
get for a specific class object or count for a number of those objects

tests for each in tests..test_engine 
test get to compare id created with id gotten
and test count for number increasing by 1 after new object created

some edge cases may not have been considered
and I don't dispute the existence of any bugs

